### PR TITLE
fixes value of 'resource' query parameter while fetching user info from IDM in IDP mode 'Authorization'

### DIFF
--- a/src/api-umbrella/utils/idp.lua
+++ b/src/api-umbrella/utils/idp.lua
@@ -25,7 +25,7 @@ local function get_idm_user_info(token, dict)
     elseif idp_back_name == "fiware-oauth2" and mode == "authorization" then
         rpath = "/user"
         idp_host = dict["idp"]["host"]
-        resource = ngx.ctx.uri
+        resource = ngx.var.request_uri
         method = ngx.ctx.request_method
         rquery = "access_token="..token.."&app_id="..app_id.."&resource="..resource.."&action="..method
     elseif idp_back_name == "fiware-oauth2" and mode == "authentication" then


### PR DESCRIPTION
query parameter 'resource' in authorization request did not contain full user request (query parameters were stripped from URL), hence permission checks for full request URL in IDM 'fiware-oauth2' failed